### PR TITLE
File::Find failure in taint mode

### DIFF
--- a/lib/Test/Version.pm
+++ b/lib/Test/Version.pm
@@ -211,7 +211,8 @@ sub version_all_ok {
 
   $name ||= "all modules in $dir have valid versions";
 
-  my @files = File::Find::Rule->perl_module->in( $dir );
+  my @files =
+    File::Find::Rule->perl_module->extras( { untaint => 1 } )->in($dir);
 
   {
     local $_IN_VERSION_ALL_OK = 1;


### PR DESCRIPTION
In Debian we are currently applying the following patch to
Test-Version.
We thought you might be interested in it too.

    Description: File::Find failure in taint mode
     When the test is run with the -T flag, File::Find will fail when attempting to
     chdir. It needs the "untaint" flag passed to avoid this.
    Bug-Debian: https://bugs.debian.org/881451

The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/libtest-version-perl.git/plain/debian/patches/untaint-find.patch

Thanks for considering,
  Damyan Ivanov,
  Debian Perl Group

```
--- a/lib/Test/Version.pm
+++ b/lib/Test/Version.pm
@@ -211,7 +211,8 @@ sub version_all_ok {
 
   $name ||= "all modules in $dir have valid versions";
 
-  my @files = File::Find::Rule->perl_module->in( $dir );
+  my @files =
+    File::Find::Rule->perl_module->extras( { untaint => 1 } )->in($dir);
 
   {
     local $_IN_VERSION_ALL_OK = 1;
```